### PR TITLE
Links in ingredient names

### DIFF
--- a/examples/example_menu.md
+++ b/examples/example_menu.md
@@ -1,0 +1,20 @@
+# Example Menu
+
+Some description.
+Tags and amounts depend on recipes.
+
+---
+
+## Main course
+
+- *4 l* [Kartoffeltopf](file:griechischer_kartoffeltopf.md)
+- *1* [Brot](file:schwarzbierbrot.md)
+
+## Dessert
+
+- *40 l* Ice Cream
+
+---
+
+Text with description for the meta recipe and how to prepare it.
+

--- a/examples/example_menu.md
+++ b/examples/example_menu.md
@@ -7,8 +7,8 @@ Tags and amounts depend on recipes.
 
 ## Main course
 
-- *4 l* [Kartoffeltopf *test*](file:griechischer_kartoffeltopf.md)
-- *1* [Brot](file:schwarzbierbrot.md)
+- *4 l* [Kartoffeltopf](griechischer_kartoffeltopf.md)
+- *1* [Brot](schwarzbierbrot.md)
 
 ## Dessert
 

--- a/examples/example_menu.md
+++ b/examples/example_menu.md
@@ -7,7 +7,7 @@ Tags and amounts depend on recipes.
 
 ## Main course
 
-- *4 l* [Kartoffeltopf](file:griechischer_kartoffeltopf.md)
+- *4 l* [Kartoffeltopf *test*](file:griechischer_kartoffeltopf.md)
 - *1* [Brot](file:schwarzbierbrot.md)
 
 ## Dessert

--- a/recipemd/data.py
+++ b/recipemd/data.py
@@ -19,6 +19,7 @@ class IngredientGroup:
     title: Optional[str] = None
     children: List[Union[Ingredient, IngredientGroup]] = field(default_factory=list)
 
+
 @dataclass
 class Amount:
     factor: Optional[Decimal] = None
@@ -28,10 +29,12 @@ class Amount:
         if self.factor is None and self.unit is None:
             raise TypeError(f"Factor and unit may not both be None")
 
+
 @dataclass
 class Ingredient:
     name: str
     amount: Optional[Amount] = None
+    link: Optional[str] = None
 
 
 @dataclass
@@ -200,26 +203,54 @@ class RecipeParser:
         self._enter_node()
 
         amount = None
-        unit = None
         first_paragraph = None
 
+        can_have_link = True
+        has_link = False
+        link_destination = None
+        link_text = None
+
         if self.current.t == 'paragraph' and self.current.first_child.t == 'emph':
+            # enter paragraph
             self._enter_node()
+            # enter emph
             self._enter_node()
             amount = self.parse_amount(self._get_node_source(self.current))
+            # leave emph
             self._exit_node()
+
+            # parse rest of first paragraph
             self._next_node()
+
             while self.current is not None:
                 if first_paragraph is None:
                     first_paragraph = ""
-                first_paragraph += self._get_node_source(self.current)
+                node_source = self._get_node_source(self.current)
+
+                if can_have_link:
+                    # to have a link, the first paragraph may only contain space and one link
+                    if not has_link and self.current.t == 'link':
+                        link_destination = self.current.destination
+                        link_text = self._get_current_node_children_source()
+                        has_link = True
+                    elif not node_source.isspace():
+                        can_have_link = False
+
+                first_paragraph += node_source
                 self._next_node()
+
+            # leave first paragraph
             self._exit_node()
             self._next_node()
 
         following_paragraphs = self._get_source_until()
 
-        if first_paragraph is not None and following_paragraphs is not None:
+        if following_paragraphs is not None and not following_paragraphs.isspace():
+            can_have_link = False
+
+        if can_have_link and has_link:
+            name = link_text
+        elif first_paragraph is not None and following_paragraphs is not None:
             name = first_paragraph + "\n\n" + following_paragraphs
         elif first_paragraph is not None:
             name = first_paragraph
@@ -231,7 +262,7 @@ class RecipeParser:
 
         self._exit_node()
 
-        return Ingredient(name=name, amount=amount)
+        return Ingredient(name=name, amount=amount, link=link_destination)
 
     @staticmethod
     def parse_amount(amount_str: str) -> Amount:
@@ -348,11 +379,12 @@ def _multiply_ingredients(ingredients: List[Union[Ingredient, IngredientGroup]],
 
 
 if __name__ == "__main__":
-    src = open('examples/schwarzbierbrot.md', 'r').read()
+    # src = open('examples/schwarzbierbrot.md', 'r').read()
     # src = open('examples/griechischer_kartoffeltopf.md', 'r').read()
+    src = open('examples/example_menu.md', 'r').read()
 
     rp = RecipeParser()
     r = rp.parse(src)
-    pprint(r.yields)
-    rs = RecipeSerializer()
-    print(rs.serialize(r))
+    pprint([i for i in r.leaf_ingredients])
+    #rs = RecipeSerializer()
+    #print(rs.serialize(r))

--- a/recipemd/data.py
+++ b/recipemd/data.py
@@ -215,17 +215,18 @@ class RecipeParser:
         link_destination = None
         link_text = None
 
-        if self.current.t == 'paragraph' and self.current.first_child.t == 'emph':
+        if self.current.t == 'paragraph':
             # enter paragraph
             self._enter_node()
-            # enter emph
-            self._enter_node()
-            amount = self.parse_amount(self._get_node_source(self.current))
-            # leave emph
-            self._exit_node()
 
-            # parse rest of first paragraph
-            self._next_node()
+            if self.current.t == 'emph':
+                # enter emph
+                self._enter_node()
+                amount = self.parse_amount(self._get_node_source(self.current))
+                # leave emph
+                self._exit_node()
+                # parse rest of first paragraph
+                self._next_node()
 
             while self.current is not None:
                 if first_paragraph is None:

--- a/recipemd/data.py
+++ b/recipemd/data.py
@@ -81,8 +81,13 @@ class RecipeSerializer:
                    + "\n".join(self._serialize_ingredient(i, level+1) for i in ingredient.children)
         else:
             if ingredient.amount is not None:
-                return f'- *{self._serialize_amount(ingredient.amount)}* {ingredient.name}'
-            return f'- {ingredient.name}'
+                return f'- *{self._serialize_amount(ingredient.amount)}* {self._serialize_ingredient_text(ingredient)}'
+            return f'- {self._serialize_ingredient_text(ingredient)}'
+
+    def _serialize_ingredient_text(self, ingredient):
+        if ingredient.link:
+            return f'[{ingredient.name}]({ingredient.link})'
+        return ingredient.name
 
     @staticmethod
     def _serialize_amount(amount):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 CommonMark==0.7.5
 commonmarkextensions==0.0.3
+yarl==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="recipemd",
-    version="2.0.0",
+    version="2.1.0",
     author="Tilman Stehr",
     author_email="tilman@tilman.ninja",
     description="Reference implementation of recipemd",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="recipemd",
-    version="2.1.0",
+    version="2.2.0",
     author="Tilman Stehr",
     author_email="tilman@tilman.ninja",
     description="Reference implementation of recipemd",

--- a/specification.md
+++ b/specification.md
@@ -91,17 +91,21 @@ An ingredient consists of
 
 - *optional* an amount
 - a name
+- *optional* a link to a recipe for the ingredient
 
 An ingredient is represented as follows:
 
 1. The amount in italics
-2. Everything following until the end of the list item is part of the name.
+2. Everything following until the end of the list item is part of the
+   name or the link as specified below:
+   1. If a name contains only an [inline-link], the [link-text]
+      represents the name of the ingredient and the [link-destination]
+      specifies a resource that contains a recipe for the ingredient
+   2. Otherwise, the text is the name and the link is not set
 
-#### Name
-
-If a name contains an [inline-link](https://spec.commonmark.org/0.28/#inline-link), the [link-text](https://spec.commonmark.org/0.28/#link-text) represents the common name of the ingredient and the [link-destination](https://spec.commonmark.org/0.28/#link-destination) specifies a resource that contains a recipe for the ingredient.
-
-Otherwise, the name is taken litteraly as the common name of the ingredient.
+[inline-link]: https://spec.commonmark.org/0.28/#inline-link
+[link-text]: https://spec.commonmark.org/0.28/#link-text
+[link-destination]: https://spec.commonmark.org/0.28/#link-destination
 
 ### Ingredient Group
 

--- a/specification.md
+++ b/specification.md
@@ -99,9 +99,9 @@ An ingredient is represented as follows:
 
 #### Name
 
-If a name contains a [inline-link](https://spec.commonmark.org/0.28/#inline-link), the [link-text](https://spec.commonmark.org/0.28/#link-text) becomes the name of the ingredient.
-If the linked recipe specifies a yield and the ingredient does not specify an amount, the yield of the linked recipe becomes the amount of the ingredient.
-The tags of the linked recipe are added to the tags of the recipe.
+If a name contains an [inline-link](https://spec.commonmark.org/0.28/#inline-link), the [link-text](https://spec.commonmark.org/0.28/#link-text) represents the common name of the ingredient and the [link-destination](https://spec.commonmark.org/0.28/#link-destination) specifies a resource that contains a recipe for the ingredient.
+
+Otherwise, the name is taken litteraly as the common name of the ingredient.
 
 ### Ingredient Group
 

--- a/specification.md
+++ b/specification.md
@@ -1,6 +1,6 @@
 # RecipeMD: Markdown Recipe Specification
 
-This is version 2.1.0 of the RecipeMD specification.
+This is version 2.2.0 of the RecipeMD specification.
 
 RecipeMD is a Markdown-based format for writing down recipes. It
 defines a certain structure which a document must follow to be a

--- a/specification.md
+++ b/specification.md
@@ -103,6 +103,7 @@ If a name contains a [link reference](https://spec.commonmark.org/0.28/#link-ref
 If the link reference specifies a title, it becomes the name of the ingredient.
 If the link reference does not specify a title, the name of the ingredient is overridden by the title of the link target.
 If the link target specifies a yield and the ingredient does not specify an amount, the yield of the target becomes the amount of the ingredient.
+The tags of the recipe become the union of the current tags and the tags of the target.
 
 ### Ingredient Group
 

--- a/specification.md
+++ b/specification.md
@@ -95,7 +95,7 @@ An ingredient consists of
 An ingredient is represented as follows:
 
 1. The amount in italics
-2. Everything following until the end of the line is part of the name.
+2. Everything following until the end of the list item is part of the name.
 
 #### Name
 

--- a/specification.md
+++ b/specification.md
@@ -1,6 +1,6 @@
 # RecipeMD: Markdown Recipe Specification
 
-This is version 2.0.1 of the RecipeMD specification.
+This is version 2.1.0 of the RecipeMD specification.
 
 RecipeMD is a Markdown-based format for writing down recipes. It
 defines a certain structure which a document must follow to be a

--- a/specification.md
+++ b/specification.md
@@ -99,11 +99,9 @@ An ingredient is represented as follows:
 
 #### Name
 
-If a name contains a [link reference](https://spec.commonmark.org/0.28/#link-reference-definitions), the title of the link target recipe becomes the name of the ingredient.
-If the link reference specifies a title, it becomes the name of the ingredient.
-If the link reference does not specify a title, the name of the ingredient is overridden by the title of the link target.
-If the link target specifies a yield and the ingredient does not specify an amount, the yield of the target becomes the amount of the ingredient.
-The tags of the recipe become the union of the current tags and the tags of the target.
+If a name contains a [inline-link](https://spec.commonmark.org/0.28/#inline-link), the [link-text](https://spec.commonmark.org/0.28/#link-text) becomes the name of the ingredient.
+If the linked recipe specifies a yield and the ingredient does not specify an amount, the yield of the linked recipe becomes the amount of the ingredient.
+The tags of the linked recipe are added to the tags of the recipe.
 
 ### Ingredient Group
 

--- a/specification.md
+++ b/specification.md
@@ -113,7 +113,7 @@ An ingredient group is a group of related ingredients, e.g. the
 ingredients making up one component of a dish. It consists of:
 
 - *optional* a title
-- 1..2 ingredients
+- 1..n ingredients
 
 
 

--- a/specification.md
+++ b/specification.md
@@ -95,7 +95,14 @@ An ingredient consists of
 An ingredient is represented as follows:
 
 1. The amount in italics
-2. Everything following is part of the name
+2. Everything following until the end of the line is part of the name.
+
+#### Name
+
+If a name contains a [link reference](https://spec.commonmark.org/0.28/#link-reference-definitions), the title of the link target recipe becomes the name of the ingredient.
+If the link reference specifies a title, it becomes the name of the ingredient.
+If the link reference does not specify a title, the name of the ingredient is overridden by the title of the link target.
+If the link target specifies a yield and the ingredient does not specify an amount, the yield of the target becomes the amount of the ingredient.
 
 ### Ingredient Group
 


### PR DESCRIPTION
Inspired by #2 

- Extend the specification to allow for link references in ingredient names.
- Use the yield of the linked recipe as an amount for the ingredient if no amount was specified.
- Use title of linked recipe as a name if the link reference has no title.