### PR TITLE
Relax version requirement for yarl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
     python_requires='>=3.7,<4',
     install_requires=[
         'dataclasses-json>=0.5.2,<0.6.0',
-        'yarl~=1.3.0',
+        'yarl>=1.3.0,<2.0.0',
         # commonmarkextension has to be vendorized due to #28. This can be removed once GovReady/CommonMark-py-Extensions#5  or we
         # remove or dependency on commonmarkextensions altogether
         # 'commonmarkextensions==0.0.5',


### PR DESCRIPTION
This change is motivated by https://github.com/dadada/nixpkgs/commit/482a1e9206ae141b7262239ca950f15f9c64dedd . Overriding dependencies would be considered bad practice and I'd like to avoid it if possible.