### PR TITLE
Relax version requirement for argcomplete

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
         # remove or dependency on commonmarkextensions altogether
         # 'commonmarkextensions==0.0.5',
         'commonmark>=0.9.1,<1.0.0',
-        'argcomplete~=1.10.0',
+        'argcomplete>=1.10.0,<2.0.0',
         'pyparsing~=2.4.2',
     ],
     extras_require={


### PR DESCRIPTION
This change is motivated by https://github.com/dadada/nixpkgs/commit/482a1e9206ae141b7262239ca950f15f9c64dedd . Overriding dependencies would be considered bad practice and I'd like to avoid it if possible.