### PR TITLE
[WIP] Add markdown YAML-metadata support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setuptools.setup(
         'pyparsing~=2.4.2',
         'markdown-it-py>=2.1.0,<3.0.0',
         'typing_extensions>=4.3.0,<5.0.0',
+        'python-frontmatter',
+        'ruamel.yaml'
     ],
     extras_require={
         'tests': tests_require,


### PR DESCRIPTION
Markdown files commonly employ a YAML header for metadata. I tend to use these with recipes for a bunch of things, such as recipe source, preparation time, etc. 

Example:
```markdown
---
source: https://www.jamieoliver.com/recipes/vegetables-recipes/parmesan-brussels-sprouts/
total_time: 30 min
vegetarian: yes
taste: savory
---

# Parmesan Brussels sprouts
...
```

For a personal project of mine, I added support for parsing this header, and also for serializing it. 

Would you be interested in merging this? If so, I would add/fix the tests.

